### PR TITLE
attach: use all children, not just the first one

### DIFF
--- a/obiscad/attach.scad
+++ b/obiscad/attach.scad
@@ -80,7 +80,7 @@ module attach(a,b)
     rotate(a=roll, v=v)  rotate(a=ang, v=raxis)
       //-- Attachable part to the origin
       translate(-pos2)
-	child(0); 
+	children([0:$children-1]);
 }
 
 


### PR DESCRIPTION
Hi there,

when using attach like 
```
attach (a, b) {
    foo();
    bar();
}
```
only the first child is used. This PR fixes that.

Cheers,
Jakob